### PR TITLE
This restructures a little bit the configuration logic to separate…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Bulldozer is a script designed to automate the process of downloading, organizin
     sudo apt-get install libwebp-dev libavif-dev
     ```
 
-4. Create your own config file, and add the things you need to override:
+4. Edit your own config file, and add any additional things you need to override:
     ```sh
     touch config.yaml
     ```
@@ -49,7 +49,7 @@ Bulldozer is a script designed to automate the process of downloading, organizin
 
 Edit the `config.yaml` file to set up your preferences and API keys. The configuration file includes pretty much all settings that are needed to customize the behavior of the script. The settings most users need to change are at the top of the configuration file. The file has comments, and it's hopefully easy enough to understand what everything does.
 
-Note that you do not need to copy the entire file, and you do not need to add values that you don't need to change. This approach means less work when new things are added to `config.default.yaml`.
+Any additional system defaults you want to change can be copied over from `config.system.yaml`.
 
 ## Upgrading
 
@@ -117,7 +117,8 @@ chmod +x bulldozer
   - torrent_creator.py: Creates torrent files.
   - utils.py: Utility functions.
 - logs/: Contains log files.
-- config.example.yaml: Example configuration file.
+- config.yaml: User configuration file.
+- config.system.yaml: System default configuration file.
 - requirements.txt: List of required Python packages.
 
 ## License

--- a/classes/utils.py
+++ b/classes/utils.py
@@ -88,10 +88,10 @@ def check_config():
     :return: True if the configuration is valid, False otherwise.
     """
     global config
-    base_config_file = Path("config.default.yaml")
+    base_config_file = Path("config.system.yaml")
     user_config_file = Path("config.yaml")
     if not base_config_file.exists():
-        log("'config.default.yaml' not found.", "error")
+        log("'config.system.yaml' not found.", "error")
         return False
     with open(base_config_file, 'r') as base_file:
         base_config = yaml.safe_load(base_file)
@@ -125,10 +125,10 @@ def load_config():
     :return: The configuration settings.
     """
     global config
-    base_config_file = Path("config.default.yaml")
+    base_config_file = Path("config.system.yaml")
     user_config_file = Path("config.yaml")
     if not base_config_file.exists():
-        log("'config.default.yaml' not found.", "error")
+        log("'config.system.yaml' not found.", "error")
         return None
     with open(base_config_file, 'r') as base_file:
         base_config = yaml.safe_load(base_file)

--- a/config.system.yaml
+++ b/config.system.yaml
@@ -28,15 +28,6 @@ keep_source_rss: false
 # The size you want the resized cover art to be
 cover_size: 800
 
-# The announce URL for the tracker
-announce_url: https://tracker.com/announce/thisismysecretkey
-
-# The API key to access the tracker
-api_key: andthisismyapikey
-
-# The URL to check for duplicates
-dupecheck_url: https://tracker.com/api/torrents/filter
-
 # How the RSS feed should be censored. Can be 'delete', 'edit'
 rss_censor_mode: delete
 


### PR DESCRIPTION
…API keys from the

default config to provide an additional layer against user error.
- Renames config.default.yaml to config.system.yaml
- Removes API keys and announce url from config.system.yaml
- Adds a config.yaml with commonly changed user configuration parameters.

Just a suggestion; understand if you don't want to do this or have a different approach.