### PR TITLE
Added docker image, auto build workflow, and updated readme

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: $cron-daily
+  push:
+    branches: [ $default-branch ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ $default-branch ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,11 +9,11 @@ on:
   schedule:
     - cron: '0 0 * * 1'
   push:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   schedule:
-    - cron: $cron-daily
+    - cron: '0 0 * * 1'
   push:
     branches: [ $default-branch ]
     # Publish semver tags as releases.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lts/ubuntu:24.04_stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /usr/bulldozer
+
+RUN apt-get update && apt-get install -y python3 python3-pip mktorrent curl libwebp-dev libavif-dev ffmpeg && ln -s $(which python3) /usr/bin/python
+ 
+RUN curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh && bash nodesource_setup.sh && apt-get install -y nodejs
+
+RUN npm install -g podcast-dl
+
+COPY ./ /usr/bulldozer
+
+RUN pip install --no-cache-dir --break-system-packages -r requirements.txt
+
+CMD ["python", "bulldozer", "--check-config"]

--- a/README.md
+++ b/README.md
@@ -119,13 +119,15 @@ To run interactively, you'll want to construct a command like this:
 docker run --pull newer -it --rm -v ./config.yaml:/usr/bulldozer/config.yaml -v ~/temp_podcasts/:/output/podcasts/ ghcr.io/tradition550/bulldozer:main /bin/bash
 ```
 Explanation: 
-- [`--pull newer`](https://docs.docker.com/reference/cli/docker/container/run/#pull) tries to pull updates to the image.
+- [`--pull always`](https://docs.docker.com/reference/cli/docker/container/run/#pull) tries to pull updates to the image.
 - `-it` and `/bin/bash` in the command drop you into a shell inside the container. This is useful because bulldozer requires interaction. If you leave these off, the default command will validate your config. 
 - [`--rm`](https://docs.docker.com/reference/cli/docker/container/run/#rm) automatically cleans up the container when it exits. This is a good default or docker has a habit of filling up your hard drive.
 - [`-v`](https://docs.docker.com/reference/cli/docker/container/run/#volume) mounts the volume following the pattern `/path/on/your/computer/:/path/on/container/`.
     - `/path/to/config.yaml:/usr/bulldozer/config.yaml` is required in order to pass your local bulldozer config.
     - `~/temp_podcasts/:/output/podcasts/` can be whatever you want. Note: the path you specify in your config is the path in the container not the host!
 - `ghcr.io/tradition550/bulldozer:main` is the name for the image. `main` will automatically update when new versions are released. The short commit sha should also work as a tag. (TODO change to lewler repo)
+
+For Mac users: You can probably get it to run with `--platform linux/x86_64` in the `docker run` command using docker desktop for mac (I tested it once). 
 
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ chmod +x bulldozer
 - `--name`: Use <input> as the podcast name.
 - `--match-titles`: Will only keep episodes matching <input> in the feed.
 
+## Running With Docker
+
+Docker should allow you to run bulldozer on mac or without installing all the native dependencies. This is a quick guide assuming you're new to docker. 
+
+To get started, first install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+
+To run interactively, you'll want to construct a command like this: 
+
+```
+docker run --pull newer -it --rm -v ./config.yaml:/usr/bulldozer/config.yaml -v ~/temp_podcasts/:/output/podcasts/ ghcr.io/tradition550/bulldozer:main /bin/bash
+```
+Explanation: 
+- [`--pull newer`](https://docs.docker.com/reference/cli/docker/container/run/#pull) tries to pull updates to the image.
+- `-it` and `/bin/bash` in the command drop you into a shell inside the container. This is useful because bulldozer requires interaction. If you leave these off, the default command will validate your config. 
+- [`--rm`](https://docs.docker.com/reference/cli/docker/container/run/#rm) automatically cleans up the container when it exits. This is a good default or docker has a habit of filling up your hard drive.
+- [`-v`](https://docs.docker.com/reference/cli/docker/container/run/#volume) mounts the volume following the pattern `/path/on/your/computer/:/path/on/container/`.
+    - `/path/to/config.yaml:/usr/bulldozer/config.yaml` is required in order to pass your local bulldozer config.
+    - `~/temp_podcasts/:/output/podcasts/` can be whatever you want. Note: the path you specify in your config is the path in the container not the host!
+- `ghcr.io/tradition550/bulldozer:main` is the name for the image. `main` will automatically update when new versions are released. The short commit sha should also work as a tag. (TODO change to lewler repo)
+
+
 ## Project Structure
 
 - bulldozer: Main script

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To get started, first install [Docker Desktop](https://www.docker.com/products/d
 To run interactively, you'll want to construct a command like this: 
 
 ```
-docker run --pull newer -it --rm -v ./config.yaml:/usr/bulldozer/config.yaml -v ~/temp_podcasts/:/output/podcasts/ ghcr.io/tradition550/bulldozer:main /bin/bash
+docker run --pull newer -it --rm -v ./config.yaml:/usr/bulldozer/config.yaml -v ~/temp_podcasts/:/output/podcasts/ ghcr.io/lewler/bulldozer:main /bin/bash
 ```
 Explanation: 
 - [`--pull always`](https://docs.docker.com/reference/cli/docker/container/run/#pull) tries to pull updates to the image.
@@ -125,7 +125,7 @@ Explanation:
 - [`-v`](https://docs.docker.com/reference/cli/docker/container/run/#volume) mounts the volume following the pattern `/path/on/your/computer/:/path/on/container/`.
     - `/path/to/config.yaml:/usr/bulldozer/config.yaml` is required in order to pass your local bulldozer config.
     - `~/temp_podcasts/:/output/podcasts/` can be whatever you want. Note: the path you specify in your config is the path in the container not the host!
-- `ghcr.io/tradition550/bulldozer:main` is the name for the image. `main` will automatically update when new versions are released. The short commit sha should also work as a tag. (TODO change to lewler repo)
+- `ghcr.io/lewler/bulldozer:main` is the name for the image. `main` will automatically update when new versions are pushed to the main branch on github. The short commit sha should also work as a tag.
 
 For Mac users: You can probably get it to run with `--platform linux/x86_64` in the `docker run` command using docker desktop for mac (I tested it once). 
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ To get started, first install [Docker Desktop](https://www.docker.com/products/d
 To run interactively, you'll want to construct a command like this: 
 
 ```
-docker run --pull newer -it --rm -v ./config.yaml:/usr/bulldozer/config.yaml -v ~/temp_podcasts/:/output/podcasts/ ghcr.io/lewler/bulldozer:main /bin/bash
+docker run --pull always -it --rm -v ./config.yaml:/usr/bulldozer/config.yaml -v ~/temp_podcasts/:/output/podcasts/ ghcr.io/lewler/bulldozer:main /bin/bash
 ```
 Explanation: 
-- [`--pull always`](https://docs.docker.com/reference/cli/docker/container/run/#pull) tries to pull updates to the image.
+- [`--pull always`](https://docs.docker.com/reference/cli/docker/container/run/#pull) tries to pull updates to the image. 
 - `-it` and `/bin/bash` in the command drop you into a shell inside the container. This is useful because bulldozer requires interaction. If you leave these off, the default command will validate your config. 
 - [`--rm`](https://docs.docker.com/reference/cli/docker/container/run/#rm) automatically cleans up the container when it exits. This is a good default or docker has a habit of filling up your hard drive.
 - [`-v`](https://docs.docker.com/reference/cli/docker/container/run/#volume) mounts the volume following the pattern `/path/on/your/computer/:/path/on/container/`.


### PR DESCRIPTION
The docker image should package the current install so it can run without installing anything native and also mac (probably windows too, but I only tested mac). 

Happy to update any of the readme or instructions if they're unclear. 

Dockerfile: 
I'm not a particular expert in python or docker, so happy to adjust how the docker image is laid out if you have opinions on the topic. 

Here's a quick demo of it working (on mac)

```
docker run  --platform linux/x86_64 -it --pull always --rm -v ./config.yaml:/usr/bulldozer/config.yaml -v ~/temp_podcasts/:/output/podcasts/ ghcr.io/tradition550/bulldozer:main /bin/bash
main: Pulling from tradition550/bulldozer
f2ba7e7a902b: Download complete
e347cdde61e4: Download complete
da77760b781c: Download complete
de44b265507a: Download complete
1322dff2fe0b: Download complete
a5d9c4c96346: Download complete
39cf9b18485c: Download complete
Digest: sha256:50f7dd9356e6af1fa4522aacf8983011c0009e4f6144646c998d030029c8aba4
Status: Downloaded newer image for ghcr.io/tradition550/bulldozer:main
root@35cb5d796843:/usr/bulldozer# python bulldozer https://feeds.soundcloud.com/users/soundcloud:users:684690716/sounds.rss --download-only
· • —– ++ ---| Bulldozer v0.6.4 |--- ++ —– • ·
✔ Downloading RSS feed
✔ Getting metadata from feed
✔ Downloading podcast episodes (33/33)
🎉Podcast downloaded!
root@35cb5d796843:/usr/bulldozer# ^C
root@35cb5d796843:/usr/bulldozer#
exit
```

The workflows/docker-publish.yml was basically just copied straight from https://github.com/actions/starter-workflows/blob/61d42c9d0c8d4a398799a581eb6ce48ca742a2bc/ci/docker-publish.yml

Notably, where it says `ghcr.io/tradition550/bulldozer:main` will switch to `ghcr.io/lewler/bulldozer:main` once it's building from the main repo. 

I think just merging this will get your action started to build. 

Local development with docker: 

You can build and use an image without committing to main by typing `docker build .` in the repo root directory. When it finishes, the last line will output a hash, that hash can be used in place of the `ghr.io/...` image name for local testing. 
