### PR TITLE
Fix syntax error in config file

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -35,7 +35,7 @@ announce_url: https://tracker.com/announce/thisismysecretkey
 tracker_source: null
 
 # Should we dupecheck the releases?
-dupecheck = false
+dupecheck: false
 
 # The API key to access the tracker
 api_key: andthisismyapikey


### PR DESCRIPTION
Fixed a syntax error in the default config file by changing `dupecheck = false` to `dupecheck: false`